### PR TITLE
Support progress bar fill from the right on Single Slider

### DIFF
--- a/src/SingleSlider.elm
+++ b/src/SingleSlider.elm
@@ -2,6 +2,7 @@ module SingleSlider exposing
     ( Model, defaultModel
     , Msg, update, subscriptions
     , view
+    , ProgressDirection(..)
     )
 
 {-| A single slider built natively in Elm
@@ -41,6 +42,7 @@ type alias Model =
     , maxFormatter : Float -> String
     , currentValueFormatter : Float -> Float -> String
     , disabled : Bool
+    , progressDirection : ProgressDirection
     }
 
 
@@ -49,6 +51,11 @@ type alias Model =
 type Msg
     = TrackClicked String
     | RangeChanged String Bool
+
+
+type ProgressDirection
+    = ProgressLeft
+    | ProgressRight
 
 
 {-| Default model
@@ -63,6 +70,7 @@ defaultModel =
     , maxFormatter = String.fromFloat
     , currentValueFormatter = defaultCurrentValueFormatter
     , disabled = False
+    , progressDirection = ProgressLeft
     }
 
 
@@ -187,12 +195,6 @@ onRangeChange shouldFetchModels =
 view : Model -> Html Msg
 view model =
     let
-        progress_ratio =
-            100 / (model.max - model.min)
-
-        progress =
-            String.fromFloat ((model.max - model.value) * progress_ratio) ++ "%"
-
         trackAttributes =
             [ Html.Attributes.class "input-range__track" ]
 
@@ -204,10 +206,13 @@ view model =
                 True ->
                     trackAttributes
 
+        progressPercentages =
+            calculateProgressPercentages model
+
         progressAttributes =
             [ Html.Attributes.class "input-range__progress"
-            , Html.Attributes.style "left" "0"
-            , Html.Attributes.style "right" progress
+            , Html.Attributes.style "left" <| String.fromFloat progressPercentages.left ++ "%"
+            , Html.Attributes.style "right" <| String.fromFloat progressPercentages.right ++ "%"
             ]
 
         progressAllAttributes =
@@ -248,6 +253,22 @@ view model =
             , div [ Html.Attributes.class "input-range-label" ] [ Html.text (model.maxFormatter model.max) ]
             ]
         ]
+
+
+{-| Returns the percentage adjusted min, max values for the range (actual min - actual max)
+-}
+calculateProgressPercentages : Model -> { left : Float, right : Float }
+calculateProgressPercentages model =
+    let
+        progressRatio =
+            100 / (model.max - model.min)
+    in
+    case model.progressDirection of
+        ProgressRight ->
+            { left = (model.value - model.min) * progressRatio, right = 0.0 }
+
+        ProgressLeft ->
+            { left = 0.0, right = (model.max - model.value) * progressRatio }
 
 
 


### PR DESCRIPTION
Previously it was forced to look like this:

![screenshot 2018-12-12 at 10 25 55](https://user-images.githubusercontent.com/371739/49863557-6f8c9100-fdf8-11e8-9a32-8f8fbc42c3af.png)


Now we can make it look like this:

![image](https://user-images.githubusercontent.com/371739/49863452-3b18d500-fdf8-11e8-81e4-8cfd62c19e97.png)
