### PR TITLE
Fix issues with SingleSlider ProgressRight

### DIFF
--- a/src/SingleSlider.elm
+++ b/src/SingleSlider.elm
@@ -104,7 +104,7 @@ update message model =
         TrackClicked newValue ->
             let
                 convertedValue =
-                    snapValue (String.toFloat newValue |> Maybe.withDefault 0) model.step
+                    snapValue (String.toFloat newValue |> Maybe.withDefault model.min) model.step
 
                 newModel =
                     { model | value = convertedValue }
@@ -175,7 +175,19 @@ onInsideRangeClick model =
         valueDecoder =
             Json.Decode.map2
                 (\rectangle mouseX ->
-                    String.fromInt (round ((model.value / rectangle.width) * mouseX))
+                    let
+                        newValue =
+                            case model.progressDirection of
+                                ProgressLeft ->
+                                    round ((model.value / rectangle.width) * mouseX)
+
+                                ProgressRight ->
+                                    round (((model.max / rectangle.width) * mouseX) + model.min)
+
+                        adjustedNewValue =
+                            clamp model.min model.max <| toFloat newValue
+                    in
+                    String.fromFloat adjustedNewValue
                 )
                 (Json.Decode.at [ "target" ] boundingClientRect)
                 (Json.Decode.at [ "offsetX" ] Json.Decode.float)

--- a/src/SingleSlider.elm
+++ b/src/SingleSlider.elm
@@ -263,13 +263,16 @@ calculateProgressPercentages model =
     let
         progressRatio =
             100 / (model.max - model.min)
+
+        value =
+            clamp model.min model.max model.value
     in
     case model.progressDirection of
         ProgressRight ->
-            { left = (model.value - model.min) * progressRatio, right = 0.0 }
+            { left = (value - model.min) * progressRatio, right = 0.0 }
 
         ProgressLeft ->
-            { left = 0.0, right = (model.max - model.value) * progressRatio }
+            { left = 0.0, right = (model.max - value) * progressRatio }
 
 
 


### PR DESCRIPTION
- [x] Clamp value when calculating percentage to force between min and max
- [x] Allow clicking on the progress bar to move the marker