### PR TITLE
fallbackView fix overlapping

### DIFF
--- a/src/DoubleSlider.elm
+++ b/src/DoubleSlider.elm
@@ -111,22 +111,14 @@ update message model =
                         LowValue ->
                             let
                                 newLowValue =
-                                    List.minimum
-                                        [ convertedValue
-                                        , model.highValue - (toFloat model.step * model.overlapThreshold)
-                                        ]
-                                        |> Maybe.withDefault model.min
+                                    Basics.min convertedValue (model.highValue - (toFloat model.step * model.overlapThreshold))
                             in
                             { model | lowValue = newLowValue }
 
                         HighValue ->
                             let
                                 newHighValue =
-                                    List.maximum
-                                        [ convertedValue
-                                        , model.lowValue + (toFloat model.step * model.overlapThreshold)
-                                        ]
-                                        |> Maybe.withDefault model.max
+                                    Basics.max convertedValue (model.lowValue + (toFloat model.step * model.overlapThreshold))
                             in
                             { model | highValue = newHighValue }
 

--- a/src/DoubleSlider.elm
+++ b/src/DoubleSlider.elm
@@ -110,19 +110,25 @@ update message model =
                     case valueType of
                         LowValue ->
                             let
-                                lowestValue =
-                                    List.minimum [ convertedValue, model.highValue - toFloat model.step ]
+                                newLowValue =
+                                    List.minimum
+                                        [ convertedValue
+                                        , model.highValue - (toFloat model.step * model.overlapThreshold)
+                                        ]
                                         |> Maybe.withDefault model.min
                             in
-                            { model | lowValue = lowestValue }
+                            { model | lowValue = newLowValue }
 
                         HighValue ->
                             let
-                                highestValue =
-                                    List.maximum [ convertedValue, model.lowValue + toFloat model.step ]
+                                newHighValue =
+                                    List.maximum
+                                        [ convertedValue
+                                        , model.lowValue + (toFloat model.step * model.overlapThreshold)
+                                        ]
                                         |> Maybe.withDefault model.max
                             in
-                            { model | highValue = highestValue }
+                            { model | highValue = newHighValue }
 
                         None ->
                             model

--- a/src/DoubleSlider.elm
+++ b/src/DoubleSlider.elm
@@ -109,10 +109,20 @@ update message model =
                 newModel =
                     case valueType of
                         LowValue ->
-                            { model | lowValue = convertedValue }
+                            let
+                                lowestValue =
+                                    List.minimum [ convertedValue, model.highValue - toFloat model.step ]
+                                        |> Maybe.withDefault model.min
+                            in
+                            { model | lowValue = lowestValue }
 
                         HighValue ->
-                            { model | highValue = convertedValue }
+                            let
+                                highestValue =
+                                    List.maximum [ convertedValue, model.lowValue + toFloat model.step ]
+                                        |> Maybe.withDefault model.max
+                            in
+                            { model | highValue = highestValue }
 
                         None ->
                             model


### PR DESCRIPTION
When we're trying to set lowValue to greater than the highValue, set the lowValue instead to (model.highValue - model.step) i.e. one step before the current max.

Vice-versa for setting the highValue.
