### PR TITLE
Double Slider refactor

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "carwow/elm-slider",
     "summary": "Elm slider implementation",
     "license": "BSD-3-Clause",
-    "version": "7.0.2",
+    "version": "8.0.0",
     "exposed-modules": [
         "DoubleSlider",
         "SingleSlider"

--- a/src/DoubleSlider.elm
+++ b/src/DoubleSlider.elm
@@ -222,15 +222,6 @@ onRangeChange valueType shouldFetchModels =
 -}
 view : Model -> Html Msg
 view model =
-    fallbackView model
-
-
-{-| Displays the slider using two inputs
-This used to be used to overcome an issue with mobile devices not supporting mouse events.
-But it's actually a simple solution which can work for mobile and desktop.
--}
-fallbackView : Model -> Html Msg
-fallbackView model =
     let
         lowValue =
             round model.lowValue
@@ -294,6 +285,13 @@ fallbackView model =
             , div [ Html.Attributes.class "input-range-label" ] [ Html.text (model.maxFormatter model.max) ]
             ]
         ]
+
+
+{-| DEPRECATED: Displays the slider
+-}
+fallbackView : Model -> Html Msg
+fallbackView model =
+    view model
 
 
 {-| Renders the current values using the formatter

--- a/src/DoubleSlider.elm
+++ b/src/DoubleSlider.elm
@@ -24,7 +24,6 @@ module DoubleSlider exposing
 -}
 
 import Browser
-import Browser.Events
 import DOM exposing (boundingClientRect)
 import Html exposing (Html, div, input)
 import Html.Attributes exposing (..)
@@ -40,12 +39,6 @@ type alias Model =
     , step : Int
     , lowValue : Float
     , highValue : Float
-    , dragging : Bool
-    , draggedValueType : SliderValueType
-    , rangeStartValue : Float
-    , thumbStartingPosition : Float
-    , dragStartPosition : Float
-    , thumbParentWidth : Float
     , overlapThreshold : Float
     , minFormatter : Float -> String
     , maxFormatter : Float -> String
@@ -63,9 +56,6 @@ type SliderValueType
 -}
 type Msg
     = TrackClicked SliderValueType String
-    | DragStart SliderValueType Int Float Float
-    | DragAt Int
-    | DragEnd
     | RangeChanged SliderValueType String Bool
 
 
@@ -79,12 +69,6 @@ defaultModel =
     , lowValue = 0
     , highValue = 100
     , overlapThreshold = 1
-    , dragging = False
-    , draggedValueType = None
-    , rangeStartValue = 0
-    , thumbStartingPosition = 0
-    , thumbParentWidth = 0
-    , dragStartPosition = 0
     , minFormatter = String.fromFloat
     , maxFormatter = String.fromFloat
     , currentRangeFormatter = defaultCurrentRangeFormatter
@@ -152,101 +136,6 @@ update message model =
                             model
             in
             ( newModel, Cmd.none, True )
-
-        DragStart valueType positionX offsetLeft offsetWidth ->
-            let
-                newModel =
-                    { model
-                        | dragging = True
-                        , draggedValueType = valueType
-                        , rangeStartValue =
-                            case valueType of
-                                LowValue ->
-                                    model.lowValue - model.min
-
-                                HighValue ->
-                                    model.highValue - model.min
-
-                                None ->
-                                    0
-                        , thumbStartingPosition = offsetLeft + 16
-                        , thumbParentWidth = offsetWidth
-                        , dragStartPosition = toFloat positionX
-                    }
-            in
-            ( newModel, Cmd.none, False )
-
-        DragAt positionX ->
-            let
-                rangeStart =
-                    case model.draggedValueType of
-                        HighValue ->
-                            model.rangeStartValue
-
-                        LowValue ->
-                            model.max - model.rangeStartValue - model.min
-
-                        None ->
-                            0
-
-                offset =
-                    case model.draggedValueType of
-                        HighValue ->
-                            model.thumbStartingPosition
-
-                        LowValue ->
-                            model.thumbParentWidth - model.thumbStartingPosition
-
-                        None ->
-                            0
-
-                ratio =
-                    rangeStart / offset
-
-                delta =
-                    toFloat positionX - model.dragStartPosition
-
-                newValue =
-                    case model.draggedValueType of
-                        HighValue ->
-                            model.min + snapValue ((offset + delta) * ratio) model.step
-
-                        LowValue ->
-                            model.min + snapValue ((model.thumbParentWidth - offset + delta) * ratio) model.step
-
-                        None ->
-                            0
-
-                newModel =
-                    if model.draggedValueType == LowValue && newValue + (toFloat model.step * model.overlapThreshold) > model.highValue then
-                        model
-
-                    else if model.draggedValueType == HighValue && newValue - (toFloat model.step * model.overlapThreshold) < model.lowValue then
-                        model
-
-                    else if newValue >= model.min && newValue <= model.max then
-                        case model.draggedValueType of
-                            LowValue ->
-                                { model | lowValue = newValue }
-
-                            HighValue ->
-                                { model | highValue = newValue }
-
-                            None ->
-                                model
-
-                    else
-                        model
-            in
-            ( newModel, Cmd.none, False )
-
-        DragEnd ->
-            ( { model
-                | dragging = False
-              }
-            , Cmd.none
-            , True
-            )
 
 
 snapValue : Float -> Int -> Float
@@ -328,16 +217,6 @@ onInsideRangeClick model =
     Json.Decode.map2 TrackClicked valueTypeDecoder valueDecoder
 
 
-onThumbMouseDown : SliderValueType -> Json.Decode.Decoder Msg
-onThumbMouseDown valueType =
-    Json.Decode.map4
-        DragStart
-        (Json.Decode.succeed valueType)
-        pageXDecoder
-        (Json.Decode.at [ "target", "offsetLeft" ] Json.Decode.float)
-        (Json.Decode.at [ "target", "offsetParent", "offsetWidth" ] Json.Decode.float)
-
-
 onRangeChange : SliderValueType -> Bool -> Json.Decode.Decoder Msg
 onRangeChange valueType shouldFetchModels =
     Json.Decode.map3
@@ -347,7 +226,16 @@ onRangeChange valueType shouldFetchModels =
         (Json.Decode.succeed shouldFetchModels)
 
 
+{-| Displays the slider
+-}
+view : Model -> Html Msg
+view model =
+    fallbackView model
+
+
 {-| Displays the slider using two inputs
+This used to be used to overcome an issue with mobile devices not supporting mouse events.
+But it's actually a simple solution which can work for mobile and desktop.
 -}
 fallbackView : Model -> Html Msg
 fallbackView model =
@@ -427,101 +315,8 @@ formatCurrentRange model =
         model.currentRangeFormatter model.lowValue model.highValue model.min model.max
 
 
-{-| Displays the slider
--}
-view : Model -> Html Msg
-view model =
-    let
-        lowValue =
-            round model.lowValue
-
-        highValue =
-            round model.highValue
-
-        progressRatio =
-            100 / (model.max - model.min)
-
-        lowThumbStartingPosition =
-            String.fromFloat ((model.lowValue - model.min) * progressRatio) ++ "%"
-
-        highThumbStartingPosition =
-            String.fromFloat ((model.highValue - model.min) * progressRatio) ++ "%"
-
-        progressLow =
-            String.fromFloat ((model.lowValue - model.min) * progressRatio) ++ "%"
-
-        progressHigh =
-            String.fromFloat ((model.max - model.highValue) * progressRatio) ++ "%"
-
-        mouseDownEvent t =
-            onThumbMouseDown t
-                |> Json.Decode.map (\msg -> { message = msg, stopPropagation = True, preventDefault = True })
-                |> Html.Events.custom "mousedown"
-    in
-    div []
-        [ div
-            [ Html.Attributes.class "input-range-container" ]
-            [ div
-                [ Html.Attributes.class "slider-thumb slider-thumb--first"
-                , Html.Attributes.style "left" lowThumbStartingPosition
-                , Html.Attributes.style "float" "left"
-                , mouseDownEvent LowValue
-                ]
-                []
-            , div
-                [ Html.Attributes.class "slider-thumb slider-thumb--second"
-                , Html.Attributes.style "left" highThumbStartingPosition
-                , Html.Attributes.style "float" "left"
-                , mouseDownEvent HighValue
-                ]
-                []
-            , div
-                [ Html.Attributes.class "input-range__track"
-                , Html.Events.on "click" (onOutsideRangeClick model)
-                ]
-                []
-            , div
-                [ Html.Attributes.class "input-range__progress"
-                , Html.Attributes.style "left" progressLow
-                , Html.Attributes.style "right" progressHigh
-                , Html.Events.on "click" (onInsideRangeClick model)
-                ]
-                []
-            ]
-        , div
-            [ Html.Attributes.class "input-range-labels-container" ]
-            [ div [ Html.Attributes.class "input-range-label" ] [ Html.text (model.minFormatter model.min) ]
-            , div
-                [ Html.Attributes.class "input-range-label input-range-label--current-value" ]
-                [ Html.text (formatCurrentRange model) ]
-            , div [ Html.Attributes.class "input-range-label" ] [ Html.text (model.maxFormatter model.max) ]
-            ]
-        ]
-
-
 {-| Returns the subscriptions necessary to run
 -}
 subscriptions : Model -> Sub Msg
 subscriptions model =
-    if model.dragging then
-        let
-            moveDecoder : Json.Decode.Decoder Msg
-            moveDecoder =
-                Json.Decode.map DragAt pageXDecoder
-
-            upDecoder : Json.Decode.Decoder Msg
-            upDecoder =
-                Json.Decode.succeed DragEnd
-        in
-        Sub.batch
-            [ Browser.Events.onMouseMove moveDecoder
-            , Browser.Events.onMouseUp upDecoder
-            ]
-
-    else
-        Sub.none
-
-
-pageXDecoder : Json.Decode.Decoder Int
-pageXDecoder =
-    Json.Decode.field "pageX" Json.Decode.int
+    Sub.none

--- a/src/DoubleSlider.elm
+++ b/src/DoubleSlider.elm
@@ -110,19 +110,25 @@ update message model =
                     case valueType of
                         LowValue ->
                             let
-                                lowestValue =
-                                    List.minimum [ convertedValue, model.highValue - toFloat model.step ]
+                                newLowValue =
+                                    List.minimum
+                                        [ convertedValue
+                                        , model.highValue - (toFloat model.step * model.overlapThreshold)
+                                        ]
                                         |> Maybe.withDefault model.min
                             in
-                            { model | lowValue = lowestValue }
+                            { model | lowValue = newLowValue }
 
                         HighValue ->
                             let
-                                highestValue =
-                                    List.maximum [ convertedValue, model.lowValue + toFloat model.step ]
+                                newHighValue =
+                                    List.maximum
+                                        [ convertedValue
+                                        , model.lowValue + (toFloat model.step * model.overlapThreshold)
+                                        ]
                                         |> Maybe.withDefault model.max
                             in
-                            { model | highValue = highestValue }
+                            { model | highValue = newHighValue }
 
                         None ->
                             model

--- a/src/DoubleSlider.elm
+++ b/src/DoubleSlider.elm
@@ -109,10 +109,20 @@ update message model =
                 newModel =
                     case valueType of
                         LowValue ->
-                            { model | lowValue = convertedValue }
+                            let
+                                lowestValue =
+                                    List.minimum [ convertedValue, model.highValue - toFloat model.step ]
+                                        |> Maybe.withDefault model.min
+                            in
+                            { model | lowValue = lowestValue }
 
                         HighValue ->
-                            { model | highValue = convertedValue }
+                            let
+                                highestValue =
+                                    List.maximum [ convertedValue, model.lowValue + toFloat model.step ]
+                                        |> Maybe.withDefault model.max
+                            in
+                            { model | highValue = highestValue }
 
                         None ->
                             model


### PR DESCRIPTION
The fallback view, once fixed for the overlapping issue #15 works perfectly fine on desktop and mobile.
If that's the case, then we have no need to check any mouse events or handle any dragging.


Changes the API, so anything calling the following fields would need to be updated
```elm
    , dragging = False
    , draggedValueType = None
    , rangeStartValue = 0
    , thumbStartingPosition = 0
    , thumbParentWidth = 0
    , dragStartPosition = 0
```