### PR TITLE
Add reverse option to single slider

### DIFF
--- a/src/SingleSlider.elm
+++ b/src/SingleSlider.elm
@@ -205,10 +205,7 @@ onInsideRangeClick model =
                             round <|
                                 case model.progressDirection of
                                     ProgressLeft ->
-                                        if model.reversed then
-                                            model.max - (model.max - adjustedValue) * (mouseX / rectangle.width)
-                                        else
-                                            (adjustedValue - model.min) * (mouseX / rectangle.width) + model.min
+                                        (adjustedValue / rectangle.width) * mouseX
 
                                     ProgressRight ->
                                         if model.reversed then
@@ -319,18 +316,15 @@ calculateProgressPercentages model =
         value =
             clamp model.min model.max model.value
     in
-    case (model.progressDirection, model.reversed) of
-        (ProgressRight, False) ->
-            { left = (value - model.min) * progressRatio, right = 0.0 }
+    case model.progressDirection of
+        ProgressRight ->
+            if model.reversed then
+                { left = 100 - (value - model.min) * progressRatio, right = 0.0 }
+            else
+                { left = (value - model.min) * progressRatio, right = 0.0 }
 
-        (ProgressLeft, False) ->
+        ProgressLeft ->
             { left = 0.0, right = (model.max - value) * progressRatio }
-
-        (ProgressLeft, True) ->
-            { left = 0.0, right = 100 - (model.max - value) * progressRatio }
-
-        (ProgressRight, True) ->
-            { left = 100 - (value - model.min) * progressRatio, right = 0.0 }
 
 
 

--- a/src/SingleSlider.elm
+++ b/src/SingleSlider.elm
@@ -42,6 +42,7 @@ type alias Model =
     , currentValueFormatter : Float -> Float -> String
     , disabled : Bool
     , progressDirection : ProgressDirection
+    , reversed : Bool
     }
 
 
@@ -72,6 +73,7 @@ defaultModel =
     , currentValueFormatter = defaultCurrentValueFormatter
     , disabled = False
     , progressDirection = ProgressLeft
+    , reversed = False
     }
 
 


### PR DESCRIPTION
This PR relates to [this PR](https://github.com/carwow/research_site/pull/5667)

The aim is to create `reversed` option to swap max and min values and add conditionals with updated calculations.

Gifs are quite in low quality, but it can be seen that insideRange outsideRange clicks, clickedValue and filtering at the bottom works fine.

*Also, I've reverted `ProgressLeft` changes since it wasn't working and we don't use it anywhere. A card to fix it and update it can be created anytime or when we decide to use ProgressLeft in somewhere*

**With `reversed = True` and `key = "lte"` in ProgressRight:**

![de-progressRight-reversed](https://user-images.githubusercontent.com/20427048/59698369-75b85b80-91e7-11e9-90cd-59e7bf9f8274.gif)

**With `reversed = False` and `key = "gte"` in ProgressRight:**
![de-gte-progressRight (1)](https://user-images.githubusercontent.com/20427048/59699391-6a662f80-91e9-11e9-9903-e9ba84994c14.gif)

