### PR TITLE
Produce differente messages for change and input events

### DIFF
--- a/src/SingleSlider.elm
+++ b/src/SingleSlider.elm
@@ -50,7 +50,7 @@ type alias Model =
 -}
 type Msg
     = TrackClicked String
-    | RangeChanged String Bool
+    | OnInput String Bool
     | OnChange String
 
 
@@ -94,7 +94,7 @@ defaultCurrentValueFormatter currentValue max =
 update : Msg -> Model -> ( Model, Cmd Msg, Bool )
 update message model =
     case message of
-        RangeChanged newValue shouldFetchModels ->
+        OnInput newValue shouldFetchModels ->
             let
                 convertedValue =
                     String.toFloat newValue |> Maybe.withDefault 0
@@ -234,9 +234,9 @@ onInsideRangeClick model =
     Json.Decode.map TrackClicked valueDecoder
 
 
-onRangeChange : Bool -> Json.Decode.Decoder Msg
-onRangeChange shouldFetchModels =
-    Json.Decode.map2 RangeChanged
+onInput : Bool -> Json.Decode.Decoder Msg
+onInput shouldFetchModels =
+    Json.Decode.map2 OnInput
         targetValue
         (Json.Decode.succeed shouldFetchModels)
 
@@ -299,7 +299,7 @@ view model =
                 , Html.Attributes.class "input-range"
                 , Html.Attributes.disabled model.disabled
                 , Html.Events.on "change" onChange
-                , Html.Events.on "input" (onRangeChange True)
+                , Html.Events.on "input" (onInput True)
                 , Html.Attributes.style "direction" <|
                     if model.reversed then
                         "rtl"


### PR DESCRIPTION
Currently, we produce the same `Msg` for both `onInput` and `onChange` events.
`onChange` fires when dragging the slider. `onInput` fires when you stop dragging the slider.  
Producing separate `Msg`s for these events gives us the opportunity to be more granular when reacting to input on the slider.  

For example, if we only want to fire an API request when the user stops drag, we can now do that by listening to the `OnChange` `Msg` type.  

This PR also exposes the `Msg` constructor so that users of the slider can pattern match on the events and respond accordingly to the `onInput` and `onChange` events.

This should be a non-breaking change because the constructors for the `Msg` type were not exposed previously so there was no way of an implementing app to know which `Msg` was being produced by the `onChange` and `onInput` handlers.