### PR TITLE
Fix double slider view

### DIFF
--- a/src/DoubleSlider.elm
+++ b/src/DoubleSlider.elm
@@ -373,8 +373,8 @@ view : DoubleSlider msg -> Html msg
 view (DoubleSlider slider) =
     div []
         [ div [ Html.Attributes.class "input-range-container" ]
-            [ RangeSlider.sliderInputView slider.commonAttributes slider.lowValueAttributes (inputDecoder (DoubleSlider slider) Low)
-            , RangeSlider.sliderInputView slider.commonAttributes slider.highValueAttributes (inputDecoder (DoubleSlider slider) High)
+            [ RangeSlider.sliderInputView slider.commonAttributes slider.lowValueAttributes (inputDecoder (DoubleSlider slider) Low) (Just "input-range--first")
+            , RangeSlider.sliderInputView slider.commonAttributes slider.highValueAttributes (inputDecoder (DoubleSlider slider) High) (Just "input-range--second")
             , RangeSlider.sliderTrackView (onOutsideRangeClick (DoubleSlider slider))
             , progressView (DoubleSlider slider)
             ]

--- a/src/DoubleSlider.elm
+++ b/src/DoubleSlider.elm
@@ -373,8 +373,8 @@ view : DoubleSlider msg -> Html msg
 view (DoubleSlider slider) =
     div []
         [ div [ Html.Attributes.class "input-range-container" ]
-            [ RangeSlider.sliderInputView slider.commonAttributes slider.lowValueAttributes (inputDecoder (DoubleSlider slider) Low) (Just "input-range--first")
-            , RangeSlider.sliderInputView slider.commonAttributes slider.highValueAttributes (inputDecoder (DoubleSlider slider) High) (Just "input-range--second")
+            [ RangeSlider.sliderInputView slider.commonAttributes slider.lowValueAttributes (inputDecoder (DoubleSlider slider) Low) [ "input-range--first" ]
+            , RangeSlider.sliderInputView slider.commonAttributes slider.highValueAttributes (inputDecoder (DoubleSlider slider) High) [ "input-range--second" ]
             , RangeSlider.sliderTrackView (onOutsideRangeClick (DoubleSlider slider))
             , progressView (DoubleSlider slider)
             ]

--- a/src/RangeSlider.elm
+++ b/src/RangeSlider.elm
@@ -27,27 +27,16 @@ onChange msg input =
     Html.Events.on "change" (Json.Decode.map msg input)
 
 
-sliderInputView : CommonAttributes -> ValueAttributes msg -> Json.Decode.Decoder Float -> Maybe String -> Html msg
-sliderInputView commonAttributes valueAttributes input extraClass =
-    let
-        baseClass =
-            "input-range"
-
-        class =
-            case extraClass of
-                Just s ->
-                    baseClass ++ " " ++ s
-
-                Nothing ->
-                    baseClass
-    in
+sliderInputView : CommonAttributes -> ValueAttributes msg -> Json.Decode.Decoder Float -> List String -> Html msg
+sliderInputView commonAttributes valueAttributes input extraClasses =
     Html.input
         [ Html.Attributes.type_ "range"
         , Html.Attributes.min <| String.fromFloat commonAttributes.min
         , Html.Attributes.max <| String.fromFloat commonAttributes.max
         , Html.Attributes.step <| String.fromFloat commonAttributes.step
         , Html.Attributes.value <| String.fromFloat valueAttributes.value
-        , Html.Attributes.class class
+        , Html.Attributes.class "input-range"
+        , Html.Attributes.classList <| List.map (\c -> ( c, True )) extraClasses
         , onChange valueAttributes.change input
         ]
         []

--- a/src/RangeSlider.elm
+++ b/src/RangeSlider.elm
@@ -27,15 +27,27 @@ onChange msg input =
     Html.Events.on "change" (Json.Decode.map msg input)
 
 
-sliderInputView : CommonAttributes -> ValueAttributes msg -> Json.Decode.Decoder Float -> Html msg
-sliderInputView commonAttributes valueAttributes input =
+sliderInputView : CommonAttributes -> ValueAttributes msg -> Json.Decode.Decoder Float -> Maybe String -> Html msg
+sliderInputView commonAttributes valueAttributes input extraClass =
+    let
+        baseClass =
+            "input-range"
+
+        class =
+            case extraClass of
+                Just s ->
+                    baseClass ++ " " ++ s
+
+                Nothing ->
+                    baseClass
+    in
     Html.input
         [ Html.Attributes.type_ "range"
         , Html.Attributes.min <| String.fromFloat commonAttributes.min
         , Html.Attributes.max <| String.fromFloat commonAttributes.max
         , Html.Attributes.step <| String.fromFloat commonAttributes.step
         , Html.Attributes.value <| String.fromFloat valueAttributes.value
-        , Html.Attributes.class "input-range"
+        , Html.Attributes.class class
         , onChange valueAttributes.change input
         ]
         []

--- a/src/SingleSlider.elm
+++ b/src/SingleSlider.elm
@@ -256,7 +256,7 @@ view : SingleSlider msg -> Html msg
 view (SingleSlider slider) =
     div []
         [ div [ class "input-range-container" ]
-            [ RangeSlider.sliderInputView slider.commonAttributes slider.valueAttributes inputDecoder
+            [ RangeSlider.sliderInputView slider.commonAttributes slider.valueAttributes inputDecoder Nothing
             , RangeSlider.sliderTrackView (onOutsideRangeClick (SingleSlider slider))
             , progressView (SingleSlider slider)
             ]

--- a/src/SingleSlider.elm
+++ b/src/SingleSlider.elm
@@ -256,7 +256,7 @@ view : SingleSlider msg -> Html msg
 view (SingleSlider slider) =
     div []
         [ div [ class "input-range-container" ]
-            [ RangeSlider.sliderInputView slider.commonAttributes slider.valueAttributes inputDecoder Nothing
+            [ RangeSlider.sliderInputView slider.commonAttributes slider.valueAttributes inputDecoder []
             , RangeSlider.sliderTrackView (onOutsideRangeClick (SingleSlider slider))
             , progressView (SingleSlider slider)
             ]


### PR DESCRIPTION
Issue for: https://github.com/carwow/elm-slider/issues/31

The new version of the slider is missing classes on the double slider that makes the 2 ranges overlap and take full width of the container element. The fix makes the double slider usable.

Before:
<img width="393" alt="Screenshot 2020-05-28 at 12 04 23" src="https://user-images.githubusercontent.com/2735740/83134385-2f989700-a0dc-11ea-856a-4d3725daf60a.png">

After:
<img width="393" alt="Screenshot 2020-05-28 at 12 07 18" src="https://user-images.githubusercontent.com/2735740/83134391-31faf100-a0dc-11ea-9c88-a970c53e9d67.png">

