### PR TITLE
Fix rounding issues when using snap values

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -14,7 +14,8 @@
         "elm/browser": "1.0.0 <= v < 2.0.0",
         "elm/core": "1.0.0 <= v < 2.0.0",
         "elm/html": "1.0.0 <= v < 2.0.0",
-        "elm/json": "1.0.0 <= v < 2.0.0"
+        "elm/json": "1.0.0 <= v < 2.0.0",
+        "myrho/elm-round": "1.0.4 <= v < 2.0.0"
     },
     "test-dependencies": {}
 }

--- a/src/RangeSlider.elm
+++ b/src/RangeSlider.elm
@@ -30,7 +30,7 @@ snapValue value step =
             step
                 |> String.fromFloat
                 |> String.split "."
-                |> List.reverse
+                |> List.drop 1
                 |> List.head
 
         precision =

--- a/src/RangeSlider.elm
+++ b/src/RangeSlider.elm
@@ -4,6 +4,7 @@ import Html exposing (Html, div)
 import Html.Attributes exposing (class, classList)
 import Html.Events exposing (on)
 import Json.Decode
+import Round exposing (roundNum)
 
 
 type alias ValueAttributes msg =
@@ -24,7 +25,25 @@ type alias CommonAttributes =
 
 snapValue : Float -> Float -> Float
 snapValue value step =
-    toFloat (round (value / step)) * step
+    let
+        stepDecimals =
+            step
+                |> String.fromFloat
+                |> String.split "."
+                |> List.reverse
+                |> List.head
+
+        precision =
+            case stepDecimals of
+                Just s ->
+                    String.length s
+
+                Nothing ->
+                    1
+    in
+    toFloat (round (value / step))
+        * step
+        |> roundNum precision
 
 
 onChange : (Float -> msg) -> Json.Decode.Decoder Float -> Html.Attribute msg

--- a/src/RangeSlider.elm
+++ b/src/RangeSlider.elm
@@ -41,8 +41,7 @@ snapValue value step =
                 Nothing ->
                     0
     in
-    toFloat (round (value / step))
-        * step
+    (toFloat (round (value / step)) * step)
         |> roundNum precision
 
 

--- a/src/RangeSlider.elm
+++ b/src/RangeSlider.elm
@@ -39,7 +39,7 @@ snapValue value step =
                     String.length s
 
                 Nothing ->
-                    1
+                    0
     in
     toFloat (round (value / step))
         * step


### PR DESCRIPTION
When using snap values, we sometimes get floats with a precision beyond what the step should allow.

![Screenshot 2020-07-16 at 16 54 53](https://user-images.githubusercontent.com/2735740/87698935-1206b600-c78c-11ea-83df-4e6b66178492.png)

After the fix:
![ezgif-1-599335db6aae](https://user-images.githubusercontent.com/2735740/87699035-2ba7fd80-c78c-11ea-8be9-feaf1d47870c.gif)
